### PR TITLE
Allow user to set event source as URL

### DIFF
--- a/src/MaddHatter/LaravelFullcalendar/Calendar.php
+++ b/src/MaddHatter/LaravelFullcalendar/Calendar.php
@@ -218,7 +218,10 @@ class Calendar
         $placeholders = $this->getCallbackPlaceholders();
         $parameters   = array_merge($options, $placeholders);
 
-        $parameters['events'] = $this->eventCollection->toArray();
+        // Allow the user to override the events list with a url
+        if (!isset($parameters['events'])) {
+            $parameters['events'] = $this->eventCollection->toArray();
+        }
 
         $json = json_encode($parameters);
 


### PR DESCRIPTION
Check for existing events parameter key in getOptionsJson prior to loading events queue.  This allows the user to set the events key in the options and set a feed url or function as the source.

It seems that getOptionsJson assumed that all events were to be added to the calendar on the Laravel side, and any attempt to set the events option setting was being clobbered.  Added a quick isset() test for the events option prior to loading it up from the eventCollection, and if it exists, leave it alone.
