### PR TITLE
Replace click action for custom buttons with non-JSON encoded values

### DIFF
--- a/src/MaddHatter/LaravelFullcalendar/Calendar.php
+++ b/src/MaddHatter/LaravelFullcalendar/Calendar.php
@@ -222,6 +222,11 @@ class Calendar
 
         $json = json_encode($parameters);
 
+		if( isset($options['customButtons']))
+		{
+			 $json = $this->replaceClickCustomButtons($json, $options['customButtons']);
+		}
+
         if ($placeholders) {
             return $this->replaceCallbackPlaceholders($json, $placeholders);
         }
@@ -266,5 +271,24 @@ class Calendar
 
         return str_replace($search, $replace, $json);
     }
+    
+    
+    /**
+     * Replace click handlers for customButtons with non-JSON encoded values
+     *
+     * @param $json
+     * @param $customButtons ($options['customButton'])
+     * @return string
+     */
+    protected function replaceClickCustomButtons($json, $customButtons)
+	{
+		foreach ($customButtons as $name => $options) {
+			if(isset($options['click']))
+			{
+				$json = str_replace(json_encode($options['click']), $options['click'], $json);
+			}
+		}
+		return $json;
+	}
 
 }


### PR DESCRIPTION
When trying to set customButtons
(http://fullcalendar.io/docs/display/customButtons/) via the options
array the click button didn’t work cause it was JSON-encoded. This code
replaces the JSON encoded version with the original code that was
provided in the options array.
