### PR TITLE
Mark package as abandoned.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
             "email": "shawn.tunney@gmail.com"
         }
     ],
+    "abandoned": true,
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~5.0"


### PR DESCRIPTION
Given this is still showing fairly high up on packagist, and has had no active development, answers from the author(s) or acceptance or acknowledgement of pull requests it's only fair to warn people that this package is abandoned to save people wasting time.